### PR TITLE
CAPA: Remove `guestCluster` key from installations info since `AWSClusterRoleIdentity` objects define where workload clusters get deployed

### DIFF
--- a/cmd/push/installations/installations.go
+++ b/cmd/push/installations/installations.go
@@ -225,9 +225,6 @@ func getNewInstallationsFromFlags(flags Config) (*installations.Installations, e
 		c.AwsHostClusterAdminRoleArn = fmt.Sprintf("arn:aws:iam::%s:role/GiantSwarmAdmin", flags.Flags.AWS.InstallationAWSAccount)
 		c.AwsHostClusterCloudtrailBucket = ""
 		c.AwsHostClusterGuardDuty = false
-		c.AwsGuestClusterAccount = flags.Flags.AWS.InstallationAWSAccount
-		c.AwsGuestClusterCloudtrailBucket = ""
-		c.AwsGuestClusterGuardDuty = false
 	}
 
 	return installations.NewInstallations(c), nil
@@ -249,7 +246,6 @@ func overrideInstallationsWithFlags(current *installations.Installations, flags 
 		c.AwsRegion = flags.Flags.AWS.Region
 		if flags.Flags.AWS.InstallationAWSAccount != "" {
 			c.AwsHostClusterAccount = flags.Flags.AWS.InstallationAWSAccount
-			c.AwsGuestClusterAccount = flags.Flags.AWS.InstallationAWSAccount
 			c.AwsHostClusterAdminRoleArn = fmt.Sprintf("arn:aws:iam::%s:role/GiantSwarmAdmin", flags.Flags.AWS.InstallationAWSAccount)
 		}
 	}

--- a/cmd/push/installations/installations_test.go
+++ b/cmd/push/installations/installations_test.go
@@ -86,11 +86,6 @@ func TestGetNewInstallationsFromFlags(t *testing.T) {
 						CloudtrailBucket: "",
 						GuardDuty:        false,
 					},
-					GuestCluster: installations.GuestCluster{
-						Account:          "123456789012",
-						CloudtrailBucket: "",
-						GuardDuty:        false,
-					},
 				},
 			},
 			expectError: false,

--- a/pkg/managementcluster/installations/installations.go
+++ b/pkg/managementcluster/installations/installations.go
@@ -24,9 +24,8 @@ type Installations struct {
 }
 
 type AwsConfig struct {
-	Region       string       `yaml:"region"`
-	HostCluster  HostCluster  `yaml:"hostCluster"`
-	GuestCluster GuestCluster `yaml:"guestCluster"`
+	Region      string      `yaml:"region"`
+	HostCluster HostCluster `yaml:"hostCluster"`
 }
 
 type HostCluster struct {
@@ -36,29 +35,20 @@ type HostCluster struct {
 	GuardDuty        bool   `yaml:"guardDuty"`
 }
 
-type GuestCluster struct {
-	Account          string `yaml:"account"`
-	CloudtrailBucket string `yaml:"cloudtrailBucket"`
-	GuardDuty        bool   `yaml:"guardDuty"`
-}
-
 type InstallationsConfig struct {
-	Base                            string
-	Codename                        string
-	Customer                        string
-	CmcRepository                   string
-	CcrRepository                   string
-	AccountEngineer                 string
-	Pipeline                        string
-	Provider                        string
-	AwsRegion                       string
-	AwsHostClusterAccount           string
-	AwsHostClusterAdminRoleArn      string
-	AwsHostClusterGuardDuty         bool
-	AwsHostClusterCloudtrailBucket  string
-	AwsGuestClusterAccount          string
-	AwsGuestClusterCloudtrailBucket string
-	AwsGuestClusterGuardDuty        bool
+	Base                           string
+	Codename                       string
+	Customer                       string
+	CmcRepository                  string
+	CcrRepository                  string
+	AccountEngineer                string
+	Pipeline                       string
+	Provider                       string
+	AwsRegion                      string
+	AwsHostClusterAccount          string
+	AwsHostClusterAdminRoleArn     string
+	AwsHostClusterGuardDuty        bool
+	AwsHostClusterCloudtrailBucket string
 }
 
 func NewInstallations(installationsConfig InstallationsConfig) *Installations {
@@ -78,11 +68,6 @@ func NewInstallations(installationsConfig InstallationsConfig) *Installations {
 				AdminRoleArn:     installationsConfig.AwsHostClusterAdminRoleArn,
 				CloudtrailBucket: installationsConfig.AwsHostClusterCloudtrailBucket,
 				GuardDuty:        installationsConfig.AwsHostClusterGuardDuty,
-			},
-			GuestCluster: GuestCluster{
-				Account:          installationsConfig.AwsGuestClusterAccount,
-				CloudtrailBucket: installationsConfig.AwsGuestClusterCloudtrailBucket,
-				GuardDuty:        installationsConfig.AwsGuestClusterGuardDuty,
 			},
 		},
 	}
@@ -151,15 +136,6 @@ func (i *Installations) Override(override *Installations) *Installations {
 	if override.Aws.HostCluster.GuardDuty {
 		installation.Aws.HostCluster.GuardDuty = override.Aws.HostCluster.GuardDuty
 	}
-	if override.Aws.GuestCluster.Account != "" {
-		installation.Aws.GuestCluster.Account = override.Aws.GuestCluster.Account
-	}
-	if override.Aws.GuestCluster.CloudtrailBucket != "" {
-		installation.Aws.GuestCluster.CloudtrailBucket = override.Aws.GuestCluster.CloudtrailBucket
-	}
-	if override.Aws.GuestCluster.GuardDuty {
-		installation.Aws.GuestCluster.GuardDuty = override.Aws.GuestCluster.GuardDuty
-	}
 	return &installation
 }
 
@@ -197,9 +173,6 @@ func (i *Installations) Validate() error {
 		}
 		if i.Aws.HostCluster.AdminRoleArn == "" {
 			return fmt.Errorf("aws host cluster admin role arn is empty")
-		}
-		if i.Aws.GuestCluster.Account == "" {
-			return fmt.Errorf("aws guest cluster account is empty")
 		}
 	}
 	return nil


### PR DESCRIPTION
Same as https://github.com/giantswarm/mc-bootstrap/pull/998