### PR TITLE
ci: attach architect context to go-build/go-test for nancy auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
   test:
     jobs:
       - architect/go-test:
+          context: architect
           name: go-test
           filters:
             # Trigger job also on git tag.


### PR DESCRIPTION
## Problem

CircleCI `go-build` / `go-test` jobs intermittently fail with:

```
Error: You have been rate limited by OSS Index.
```

Sonatype changed OSS Index limits and the anonymous tier no longer absorbs CI traffic. Per giantswarm team-shield (who own nancy), the fix is to attach the existing `architect` CircleCI context -- which already contains OSS Index credentials -- to the build job, not only the push jobs.

## Change

Adds `context: architect` to the `architect/go-build` (or `architect/go-test`) job in `.circleci/config.yml`. Already present on every other job that uses architect-orb commands.

Same fix as giantswarm/mcp-kubernetes#383.

Made with [Cursor](https://cursor.com)