### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@9.0.0
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   test:
@@ -13,3 +13,22 @@ workflows:
             # Trigger job also on git tag.
             tags:
               only: /^v.*/
+      - architect/go-build:
+          context: architect
+          name: go-build
+          binary: mcli
+          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
+          filters:
+            tags:
+              only: /^v.*/
+          requires:
+            - go-test
+      - architect/upload-release-assets:
+          context: architect
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+          requires:
+            - go-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ workflows:
           requires:
             - go-test
       - architect/upload-release-assets:
+          binary: mcli
           context: architect
           filters:
             branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add JSON schema headers to `cluster.yaml` if `schema.json` is present in the installation repository
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `mcli-windows-<arch>.exe`.
+
 ## [0.2.0] - 2024-12-19
 
 ### Added


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: uploads signed bare binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and adds cosign keyless signing and SBOM attestations.

Same pattern as giantswarm/muster#796.